### PR TITLE
fix(client): close browser-burndown interaction gaps + pre-existing type/SSOT debt

### DIFF
--- a/packages/client/components/automation/AutomationRunsTable.vue
+++ b/packages/client/components/automation/AutomationRunsTable.vue
@@ -8,6 +8,7 @@ import {
   FLUID_WIDTH_CLASS,
   GHOST_ACTION_CLASS,
   INSET_PANEL_CLASS,
+  MAX_W_48_CLASS,
   PADDING_TOKEN_CLASS,
   PRIMARY_ACTION_CLASS,
   STACK_SPACE_Y_TOKEN_CLASS,
@@ -167,7 +168,7 @@ const formatRunJobLabel = (run: RpaRunExecutionEnvelope): string => {
                   </div>
                 </td>
                 <td class="text-end">{{ formatRunProgress(run) }}</td>
-                <td class="max-w-48 truncate">{{ formatRunJobLabel(run) }}</td>
+                <td class="truncate" :class="[MAX_W_48_CLASS]">{{ formatRunJobLabel(run) }}</td>
                 <td>{{ formatDate(run.updatedAt) }}</td>
                 <td>
                   <NuxtLink

--- a/packages/client/composables/usePortfolioPage.ts
+++ b/packages/client/composables/usePortfolioPage.ts
@@ -8,6 +8,7 @@ import { usePortfolioPageActions } from "~/composables/portfolio-page-actions";
 import { usePortfolioPageDerived } from "~/composables/portfolio-page-derived";
 import {
   PORTFOLIO_PROJECT_DIALOG_TITLE_ID,
+  normalizePortfolioProject,
   usePortfolioPageState,
 } from "~/composables/portfolio-page-state";
 
@@ -39,7 +40,7 @@ export function usePortfolioPage() {
     if (typeof projectId === "string" && projectId.length > 0) {
       const match = portfolioApi.projects.value.find((project) => project.id === projectId);
       if (match) {
-        state.openEditModal(match);
+        state.openEditModal(normalizePortfolioProject(match));
       }
     }
   }

--- a/packages/client/constants/layout-tokens.ts
+++ b/packages/client/constants/layout-tokens.ts
@@ -316,6 +316,7 @@ export const PRINT_PADDING_RESET_CLASS = "print:p-0";
 export const MAX_W_2XL_CLASS = "max-w-2xl";
 export const MAX_W_3XL_CLASS = "max-w-3xl";
 export const MAX_W_40_CLASS = "max-w-40";
+export const MAX_W_48_CLASS = "max-w-48";
 export const MAX_W_64_CLASS = "max-w-64";
 export const MAX_W_XS_CLASS = "max-w-xs";
 

--- a/packages/client/constants/layout.ts
+++ b/packages/client/constants/layout.ts
@@ -235,6 +235,7 @@ export const PRINT_PADDING_RESET_CLASS = tokens.PRINT_PADDING_RESET_CLASS;
 export const MAX_W_2XL_CLASS = tokens.MAX_W_2XL_CLASS;
 export const MAX_W_3XL_CLASS = tokens.MAX_W_3XL_CLASS;
 export const MAX_W_40_CLASS = tokens.MAX_W_40_CLASS;
+export const MAX_W_48_CLASS = tokens.MAX_W_48_CLASS;
 export const MAX_W_64_CLASS = tokens.MAX_W_64_CLASS;
 export const MAX_W_XS_CLASS = tokens.MAX_W_XS_CLASS;
 export const STATS_SHELL_VARIANT_CLASS = tokens.STATS_SHELL_VARIANT_CLASS;

--- a/packages/client/locales/en-US/gamificationPage.ts
+++ b/packages/client/locales/en-US/gamificationPage.ts
@@ -8,6 +8,8 @@ const gamificationPage = {
     loadErrorFallback: "Failed to load gamification data",
     retryButtonLabel: "Retry",
     retryAria: "Retry loading gamification data",
+    refreshButtonLabel: "Refresh",
+    refreshAria: "Refresh gamification data",
     emptyStateTitle: "No progression data yet",
     emptyStateDescription:
       "Complete setup tasks, start interview practice, and take daily challenges to begin earning XP and unlocking achievements.",

--- a/packages/client/locales/en-US/resumeBuildPage.ts
+++ b/packages/client/locales/en-US/resumeBuildPage.ts
@@ -43,6 +43,8 @@ const resumeBuildPage = {
       experienceAria: "Experience level",
       generateButton: "Generate Questions",
       generateAria: "Generate tailored CV questions",
+      backToResumesButton: "Back to resumes",
+      backToResumesAria: "Return to resumes list",
     },
     questions: {
       title: "Question {current} of {total}",

--- a/packages/client/pages/gamification/index.vue
+++ b/packages/client/pages/gamification/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { STACK_SPACE_Y_TOKEN_CLASS } from "~/constants/layout";
+import { STACK_SPACE_Y_TOKEN_CLASS, SECONDARY_ACTION_CLASS } from "~/constants/layout";
 import { PERCENT_MAX } from "~/constants/numeric-ui";
 
 definePageMeta({
@@ -174,7 +174,18 @@ async function handleCompleteChallenge(challengeId: string) {
       title-id="gamification-title"
       :title="t('gamificationPage.pageTitle')"
       :description="t('gamificationPage.metricsSummary', { brand: resolvedBrand.name })"
-    />
+    >
+      <template #actions>
+        <button
+          type="button"
+          :class="[SECONDARY_ACTION_CLASS]"
+          :aria-label="t('gamificationPage.refreshAria')"
+          @click="retryPageLoad"
+        >
+          {{ t("gamificationPage.refreshButtonLabel") }}
+        </button>
+      </template>
+    </PageHeroHeader>
 
     <LoadingSkeleton
       v-if="uiState === 'loading' || uiState === 'idle'"

--- a/packages/client/pages/resume/build/index.vue
+++ b/packages/client/pages/resume/build/index.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { RESUME_BUILD_PROGRESS } from "~/constants/numeric-ui";
-import { FLUID_WIDTH_CLASS, MARGIN_TOKEN_CLASS } from "~/constants/layout";
+import { FLUID_WIDTH_CLASS, MARGIN_TOKEN_CLASS, SECONDARY_ACTION_CLASS } from "~/constants/layout";
 
 definePageMeta({
   middleware: ["auth"],
 });
 
-import { APP_ROUTE_BUILDERS } from "@bao/shared/constants/routes";
+import { APP_ROUTE_BUILDERS, APP_ROUTES } from "@bao/shared/constants/routes";
 import { useI18n } from "vue-i18n";
 import { settlePromise } from "~/composables/async-flow";
 import { getErrorMessage } from "~/utils/errors";
@@ -185,7 +185,17 @@ function backToTarget() {
       title-id="resume-build-title"
       :title="t('resumeBuildPage.title')"
       :description="t('resumeBuildPage.subtitle')"
-    />
+    >
+      <template #actions>
+        <NuxtLink
+          :to="APP_ROUTES.resume"
+          :class="[SECONDARY_ACTION_CLASS]"
+          :aria-label="t('resumeBuildPage.target.backToResumesAria')"
+        >
+          {{ t("resumeBuildPage.target.backToResumesButton") }}
+        </NuxtLink>
+      </template>
+    </PageHeaderBlock>
 
     <progress
       class="progress progress-primary" :class="[FLUID_WIDTH_CLASS, MARGIN_TOKEN_CLASS.mb8]"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`bun run proof:browser-burndown` (mobile → tablet → desktop, 27 routes × 3 viewports) flagged **6 ledger fails**, all `interactions=FAIL: no clickable controls` on two routes' initial state. This PR closes those gaps and two pre-existing main-branch gaps that blocked `bun run lint`/`typecheck`.

## Burndown gaps (the ask)

- **`/gamification`** — success state rendered only display-only cards (no claimable challenges on a fresh DB), so the interaction probe found 0 clickable controls in `<main>`. Added a **Refresh** button in the `PageHeroHeader` `actions` slot (calls the existing `refresh()`).
- **`/resume/build`** — the only control in `<main>` was the **disabled** "Generate Questions" button (needs a target role). Added a **Back to resumes** `NuxtLink` in the `PageHeaderBlock` `actions` slot (always enabled).

Both use `SECONDARY_ACTION_CLASS` (SSOT) + i18n keys (`en-US`; `ja-JP`/`fr-FR`/`es-ES` inherit via `mergeLocaleCatalog`).

**Result:** `proof:browser-burndown` now exits 0 — `81 page×viewport, 0 errors, 0 ledger fails, 0 findings`.

## Pre-existing main-branch debt also fixed (safe, sanctioned)

- `usePortfolioPage.ts` — `openEditModal(match)` passed a `PortfolioProjectView` (`DeepReadonly`) to a parameter typed `PortfolioProject` (mutable `technologies`), causing `error TS2345` and blocking `bun run typecheck`. Wrapped with the purpose-built `normalizePortfolioProject()`. Verified pre-existing (reproduces with these changes stashed).
- `AutomationRunsTable.vue:170` — inline `max-w-48` violated `validate:no-raw-design-tokens`. Added `MAX_W_48_CLASS` to the `layout-tokens` SSOT (re-exported via `layout.ts`, matching the existing `MAX_W_40_CLASS`/`MAX_W_64_CLASS` pattern) and referenced it.

## Verification

- `proof:browser-smoke` → 93 captures, 0 failures.
- `proof:browser-burndown` → exit 0 (0 fails).
- `bun run --cwd packages/client typecheck` → exit 0.
- `bun run --cwd packages/client test` → 29 files / 124 tests pass.
- Targeted validators pass: `validate:i18n-parity`, `validate:no-dead-i18n-keys`, `validate:no-hardcoded-user-strings`, `validate:empty-state-ctas`, `validate:touch-target-density`, `validate:primary-action-density`, `validate:aria`, `validate:ghost-action-ssot`, `validate:layout-token-imports`, `validate:no-raw-design-tokens` (max-w-48 resolved).

## Remaining pre-existing debt (NOT addressed — needs dedicated, visually-verified refactor)

`ResumePreviewDocument.vue:35` uses `rgb(...)` in a `toCssRgb` helper for **dynamic per-template resume export colors**. The sanctioned fix (set channel-triplet CSS vars in the component, wrap with `rgb(var(...))` in `main.css`) is a substantial refactor of core resume preview/PDF rendering that can't be visually color-verified in an autonomous run. Left as-is; flagged for a dedicated refactor. This is the only remaining `validate:no-raw-design-tokens` violation and is pre-existing from PR #28.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32cf3b7d-35f7-4981-afe2-d9aa7e8528ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32cf3b7d-35f7-4981-afe2-d9aa7e8528ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

