### PR TITLE
ci: fail-fast per-step timeouts (lint/test/build/verify)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,17 @@ jobs:
         run: bun run automation:browsers:install
 
       - name: Run lint
+        timeout-minutes: 20
         run: bun run lint
 
       - name: Run tests
+        timeout-minutes: 20
         run: bun run test
 
       - name: Build production bundles
+        timeout-minutes: 25
         run: bun run build:verify
 
       - name: Verify SSR routes
+        timeout-minutes: 10
         run: bun run verify:pages

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -89,17 +89,21 @@ jobs:
         run: bun run automation:browsers:install
 
       - name: Run lint
+        timeout-minutes: 20
         run: bun run lint
 
       - name: Run typecheck
+        timeout-minutes: 15
         run: bun run typecheck
 
       # Uses package.json (workspace filters + scripts/*.test.ts). Do not replace with bare `bun test`
       # at repo root without bunfig pathIgnorePatterns — Tauri target/ can contain copied tests.
       - name: Run tests
+        timeout-minutes: 20
         run: bun run test
 
       - name: Run SSR build
+        timeout-minutes: 25
         run: bun run build
 
   build-macos:
@@ -212,6 +216,7 @@ jobs:
         run: bun run release:desktop:macos -- --output-root .desktop-release-artifacts --no-sync-release-dir
 
       - name: Verify packaged desktop runtime
+        timeout-minutes: 10
         run: bun run verify:desktop-runtime -- --target aarch64-apple-darwin
 
       # Stapler + verify --release require a stapled notarization ticket. Skip when Apple API / signing
@@ -337,6 +342,7 @@ jobs:
         run: bun run release:desktop:windows -- --output-root .desktop-release-artifacts --release --no-sync-release-dir
 
       - name: Verify packaged desktop runtime
+        timeout-minutes: 10
         shell: pwsh
         run: bun run verify:desktop-runtime -- --target x86_64-pc-windows-msvc
 
@@ -450,6 +456,7 @@ jobs:
         run: bun run release:desktop:linux-x64 -- --output-root .desktop-release-artifacts --verbose --release --no-sync-release-dir
 
       - name: Verify packaged desktop runtime
+        timeout-minutes: 10
         run: bun run verify:desktop-runtime -- --target x86_64-unknown-linux-gnu
 
       - name: Verify Linux x64 release artifacts
@@ -545,6 +552,7 @@ jobs:
         run: bun run release:desktop:linux-arm64 -- --output-root .desktop-release-artifacts --verbose --release --no-sync-release-dir
 
       - name: Verify packaged desktop runtime
+        timeout-minutes: 10
         run: bun run verify:desktop-runtime -- --target aarch64-unknown-linux-gnu
 
       - name: Verify Linux ARM64 release artifacts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds per-step `timeout-minutes` to the `ci` and `desktop-release` workflows so a hanging step fails fast with a clear step-level signal instead of burning the full job budget.

## Why

After PR #32 merged, the post-merge `ci` run on `main` (commit `a58eed5`) hung at the "Run lint" step until the 60-min job timeout killed it — no useful log was retained. The same code passed `ci` on the PR and passed `bun run lint` inside `desktop-release` quality-gates on the same commit, so this was a runner flake, not a code issue. The pain: a single hanging step burned the entire 60-min job budget and surfaced nothing actionable.

## Change

Per-step `timeout-minutes` (all well above normal durations, below the job cap):

| Workflow / step | timeout |
|---|---|
| `ci` → Run lint | 20 |
| `ci` → Run tests | 20 |
| `ci` → Build production bundles | 25 |
| `ci` → Verify SSR routes | 10 |
| `desktop-release` quality-gates → Run lint | 20 |
| `desktop-release` quality-gates → Run typecheck | 15 |
| `desktop-release` quality-gates → Run tests | 20 |
| `desktop-release` quality-gates → Run SSR build | 25 |
| `desktop-release` build-{macos,windows,linux-x64,linux-arm64} → Verify packaged desktop runtime | 10 |

Job-level `timeout-minutes` caps remain as the overall backstop. A flake now fails in ~10-25 min with a step-level timeout error instead of a 60-min hang.

## Verification

- YAML validated (both files parse cleanly).
- `bun run lint` green locally on the merged `main` code (0 errors; all validators + eslint + biome + workspace typecheck) — confirms the post-merge `ci` hang was environmental, not a code regression.
- FTP (`pixie-ss1-ftp.porkbun.com` / `bao.builders`) re-verified: all 8 canonical binaries present with correct sizes; `manifest.json` matches the repo (except `generatedAt`).
- `desktop-release` (full 4-OS native Tauri build + assemble) already PASSED on `main` (commit `a58eed5`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27548474-945e-4a0a-950d-37e6f601e9d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27548474-945e-4a0a-950d-37e6f601e9d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

