### PR TITLE
Fix docs-site deploy: install rpm2cpio in workflow + point canonical at live bao.builders

### DIFF
--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -78,6 +78,16 @@ jobs:
       - name: Install workspace dependencies
         run: bun ci
 
+      # `verify:desktop-releases` extracts every Linux package payload to confirm
+      # the bundled runtime contract. RPM extraction shells out to `rpm2cpio | cpio`,
+      # and `rpm2cpio` is not preinstalled on ubuntu-24.04, so the deploy would fail
+      # at verification (and never publish) without these. `rpm2cpio` is the minimal
+      # package; `cpio` is its stream consumer.
+      - name: Install Linux release verification tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cpio rpm2cpio
+
       - name: Verify desktop release artifacts
         timeout-minutes: 15
         run: bun run verify:desktop-releases

--- a/docs/DOCS_SITE_DEPLOY.md
+++ b/docs/DOCS_SITE_DEPLOY.md
@@ -1,6 +1,6 @@
 # Docs Site Deployment
 
-How the public download site (`docs/`, served at <https://baobuildbuddy.com>) gets published
+How the public download site (`docs/`, served at <https://bao.builders>) gets published
 to the FTP-backed static host.
 
 ## What ships

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>BaoBuildBuddy | AI Help For Videogame Job Seekers</title>
     <meta name="description" content="BaoBuildBuddy helps videogame job seekers find roles, tailor applications, set up Ollama, and move through repetitive application steps faster." />
-    <link rel="canonical" href="https://baobuildbuddy.com/" />
+    <link rel="canonical" href="https://bao.builders/" />
     <meta name="theme-color" content="#2d3570" />
     <meta name="color-scheme" content="light dark" />
 
@@ -14,7 +14,7 @@
     <meta property="og:site_name" content="BaoBuildBuddy" />
     <meta property="og:title" content="BaoBuildBuddy | AI Help For Videogame Job Seekers" />
     <meta property="og:description" content="Download the app for your OS, connect Ollama in a few minutes, and get help pulling together game jobs, writing stronger applications, and handling repetitive applying steps." />
-    <meta property="og:url" content="https://baobuildbuddy.com/" />
+    <meta property="og:url" content="https://bao.builders/" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="BaoBuildBuddy | AI Help For Videogame Job Seekers" />
     <meta name="twitter:description" content="Free open-source desktop app that helps videogame job seekers find roles, tailor applications, and run private local AI via Ollama." />

--- a/scripts/deploy-docs-site-ftp.ts
+++ b/scripts/deploy-docs-site-ftp.ts
@@ -1,7 +1,7 @@
 /**
  * Publishes the staged docs site to the static web host over FTPS.
  *
- * The site (https://baobuildbuddy.com) is served from an FTP-backed static host,
+ * The site (https://bao.builders) is served from an FTP-backed static host,
  * and nothing in the repo previously drove that upload — the page and its release
  * artifacts were generated but never shipped. This is that missing step.
  *


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ran the docs-site build → verify → bundle → FTPS publish pipeline end-to-end for the latest committed release set (v0.1.0) and fixed the two errors it surfaced. The site is now live and correct at **https://bao.builders/**.

## What was run

- `bun install` (pinned `bun@1.3.14`)
- `git lfs pull --include="packages/desktop/releases/**"` — release binaries are Git LFS objects; pulled the real 641 MiB so the bundler doesn't fail-closed on 133-byte pointers
- `bun run build:docs-site` — Tailwind v4.3.3 + daisyUI 5.7.4 CSS + `docs/releases/manifest.json` (v0.1.0, 3 platforms, 8 files)
- `bun run verify:desktop-releases` — all artifacts, signatures, and checksums pass
- `bun run docs-site:bundle` — staged 7 page files + 8 release artifacts into `dist/docs-site`
- `bun run docs-site:deploy` — published 15 files / 641.0 MiB to `pixie-ss1-ftp.porkbun.com/` (explicit FTPS)

## Errors surfaced and fixed

### 1. `deploy-docs-site.yml` can't verify RPMs on the runner (CI bug)
`verify:desktop-releases` extracts every Linux package payload to confirm the bundled runtime contract, and RPM extraction shells out to `rpm2cpio | cpio`. `desktop-release.yml` installs `cpio`+`rpm` for its own verify step, but `deploy-docs-site.yml` (wired in #34) had **no** equivalent install step, and `rpm2cpio` is not preinstalled on `ubuntu-24.04`. Result: the deploy workflow fails at verification and never publishes.

**Fix:** add an "Install Linux release verification tools" step (`cpio` + `rpm2cpio`, the minimal set the verifier requires) before `verify:desktop-releases`. Idempotent if already present; mirrors the existing `desktop-release.yml` pattern. The verifier's hard-fail on a missing `rpm2cpio` is intentional (avoids `rpm2cpio <missing> | cpio` exiting 0 and false-passing), so the fix is to provision the tool, not weaken the check.

### 2. Deployed page canonical/og:url pointed at a dead domain (SEO/social bug)
The site is served from the FTP account bound to **`bao.builders`** (FTP user `bao.builders`), and `baobuildbuddy.com` returns **NXDOMAIN** (no DNS). Yet `docs/index.html` declared `<link rel=canonical>` and `og:url` as `https://baobuildbuddy.com/`, pointing search engines and social crawlers at a non-resolving domain. `https://bao.builders/` is already the canonical public URL used throughout `README.md` and `packages/desktop/releases/README.md`.

**Fix:** set canonical and `og:url` to `https://bao.builders/`; update the deploy doc and the deploy script's header comment to match so the repo no longer references the dead apex. All other `baobuildbuddy` occurrences in `index.html` are correct GitHub repo links (`github.com/d4551/baobuildbuddy`) and were left untouched.

## Live verification (after re-deploy)

```
curl https://bao.builders/
  <link rel="canonical" href="https://bao.builders/" />
  <meta property="og:url"   content="https://bao.builders/" />
curl https://bao.builders/releases/manifest.json
  "version": "0.1.0"   (generatedAt 2026-07-28T00:25:03Z)
curl -I https://bao.builders/releases/macos/BaoBuildBuddy_0.1.0_aarch64.dmg
  HTTP/2 200, content-length 67184004   (matches committed sha256.txt + sizes.json)
```

## Notes

- The release binaries themselves were **not** rebuilt (they require native macOS/Windows/Linux-ARM hosts, code signing, and notarization — out of scope here). The committed v0.1.0 binaries in `packages/desktop/releases/` are the latest verified builds; this PR only rebuilds the docs site from them and ships it.
- FTP credentials were used from the environment only and are **not** committed (the deploy script reads `BAO_DOCS_FTP_HOST`/`USER`/`PASSWORD` from env and refuses to run otherwise). The password was handled in this session; per `docs/DOCS_SITE_DEPLOY.md` it should be rotated at the host before being stored as a repository secret.
- `git lfs pull` left the release binaries smudged in the working tree (shown as modified by `git status`); their sha256 matches the committed LFS pointer oids, so they are **not** part of this PR — only the four code/doc files below are committed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33a6822f-9887-44b6-ae6a-c1882dec42cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33a6822f-9887-44b6-ae6a-c1882dec42cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

