### PR TITLE
Improve docs-site UI/UX + mobile/tablet responsiveness (bao.builders)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,11 +2,12 @@
 <html lang="en" data-theme="corporate">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>BaoBuildBuddy | AI Help For Videogame Job Seekers</title>
     <meta name="description" content="BaoBuildBuddy helps videogame job seekers find roles, tailor applications, set up Ollama, and move through repetitive application steps faster." />
     <link rel="canonical" href="https://bao.builders/" />
     <meta name="theme-color" content="#2d3570" />
+    <meta name="theme-color" content="#1a1a2e" media="(prefers-color-scheme: dark)" />
     <meta name="color-scheme" content="light dark" />
 
     <!-- Open Graph / social -->
@@ -43,7 +44,7 @@
       }
 
       html {
-        scroll-padding-top: 5rem;
+        scroll-padding-top: 5.5rem;
       }
 
       /* Skip-to-content link (a11y) */
@@ -137,12 +138,20 @@
         background: radial-gradient(circle, oklch(var(--color-info) / 0.24), transparent 68%);
       }
 
+      /* 3 OS tabs always fit one row on phones — minmax(0,1fr) lets them shrink
+         instead of forcing a 30rem row that overflows into horizontal scroll. */
       .downloads-tablist {
-        grid-template-columns: repeat(3, minmax(10rem, 1fr));
+        grid-template-columns: repeat(3, minmax(0, 1fr));
       }
 
       .downloads-tab {
         min-height: 3.5rem;
+        min-width: 0;
+      }
+      .downloads-tab .tab-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       .release-grid {
@@ -175,10 +184,13 @@
         font-family: var(--font-mono);
         font-size: 0.7rem;
         letter-spacing: 0.02em;
+        flex-wrap: wrap;
+        row-gap: 0.25rem;
       }
       .release-sha code {
         display: inline-block;
-        max-width: 12rem;
+        max-width: 100%;
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -247,13 +259,11 @@
       }
 
       @media (max-width: 767px) {
+        /* Tabs now fit one row (minmax(0,1fr)); keep the scroller only as a
+           safety net for ultra-narrow viewports so content never clips. */
         .downloads-tab-scroller {
           overflow-x: auto;
-          padding-bottom: 0.25rem;
-        }
-        .downloads-tablist {
-          width: max-content;
-          min-width: 100%;
+          -webkit-overflow-scrolling: touch;
         }
       }
 
@@ -284,7 +294,7 @@
     <header class="fixed inset-x-0 top-0 z-50 border-b border-base-300 bg-base-100/88 backdrop-blur">
       <div class="navbar page-shell min-h-16 px-4 sm:min-h-20 sm:px-6 lg:px-8">
       <div class="navbar-start">
-        <details class="dropdown lg:hidden">
+        <details class="dropdown md:hidden">
           <summary class="btn btn-ghost btn-circle btn-sm mr-2 list-none" aria-label="Open navigation menu">
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
@@ -310,11 +320,11 @@
           <span class="hidden sm:inline">BaoBuildBuddy</span>
         </a>
       </div>
-      <nav class="navbar-center hidden lg:flex" aria-label="Main Navigation">
+      <nav class="navbar-center hidden md:flex" aria-label="Main Navigation">
         <ul class="menu menu-horizontal px-1 gap-2 font-medium">
-          <li><a href="#downloads" data-nav-target="downloads" aria-label="Go to Downloads section" class="h-10 flex items-center">Downloads</a></li>
-          <li><a href="#ollama" data-nav-target="ollama" aria-label="Go to Ollama setup section" class="h-10 flex items-center">Set Up Ollama</a></li>
-          <li><a href="#how-it-helps" data-nav-target="how-it-helps" aria-label="Go to how BaoBuildBuddy helps section" class="h-10 flex items-center">How It Helps</a></li>
+          <li><a href="#downloads" data-nav-target="downloads" aria-label="Go to Downloads section" class="h-11 flex items-center">Downloads</a></li>
+          <li><a href="#ollama" data-nav-target="ollama" aria-label="Go to Ollama setup section" class="h-11 flex items-center">Set Up Ollama</a></li>
+          <li><a href="#how-it-helps" data-nav-target="how-it-helps" aria-label="Go to how BaoBuildBuddy helps section" class="h-11 flex items-center">How It Helps</a></li>
         </ul>
       </nav>
       <div class="navbar-end gap-3">
@@ -350,7 +360,7 @@
             <span class="badge badge-outline badge-neutral font-medium" data-app-version-badge>v0.1.0</span>
           </div>
 
-          <h1 id="hero-heading" class="text-4xl md:text-6xl lg:text-7xl font-bold font-display tracking-tight text-balance leading-tight text-base-content">
+          <h1 id="hero-heading" class="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold font-display tracking-tight text-balance leading-tight text-base-content">
             Use AI to move faster in videogame job hunting
           </h1>
 
@@ -407,9 +417,9 @@
           <label class="downloads-tab tab flex items-center justify-center gap-2 font-medium hover:bg-base-200 transition-colors" aria-label="Windows Downloads">
             <input type="radio" name="os_tabs" aria-controls="panel-windows" checked="checked" />
             <svg aria-hidden="true" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M96 96H247V247H96" fill="#f24f23"></path><path d="M265 96V247H416V96" fill="#7eba03"></path><path d="M96 265H247V416H96" fill="#3ca4ef"></path><path d="M265 265H416V416H265" fill="#f9ba00"></path></svg>
-            Windows
+            <span class="tab-label">Windows</span>
           </label>
-          <div role="tabpanel" id="panel-windows" class="tab-content pt-10 col-span-3">
+          <div role="tabpanel" id="panel-windows" class="tab-content pt-6 sm:pt-10 col-span-3">
             <div class="text-center mb-6">
               <svg aria-hidden="true" class="mx-auto w-12 h-12 mb-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M96 96H247V247H96" fill="#f24f23"></path><path d="M265 96V247H416V96" fill="#7eba03"></path><path d="M96 265H247V416H96" fill="#3ca4ef"></path><path d="M265 265H416V416H265" fill="#f9ba00"></path></svg>
               <h3 class="text-xl font-bold">Windows downloads</h3>
@@ -434,9 +444,9 @@
           <label class="downloads-tab tab flex items-center justify-center gap-2 font-medium hover:bg-base-200 transition-colors" aria-label="macOS Downloads">
             <input type="radio" name="os_tabs" aria-controls="panel-macos" />
             <svg aria-hidden="true" class="w-5 h-5 text-base-content" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1195 1195"><path fill="currentColor" d="M1006.933 812.8c-32 153.6-115.2 211.2-147.2 249.6-32 25.6-121.6 25.6-153.6 6.4-38.4-25.6-134.4-25.6-166.4 0-44.8 32-115.2 19.2-128 12.8-256-179.2-352-716.8 12.8-774.4 64-12.8 134.4 32 134.4 32 51.2 25.6 70.4 12.8 115.2-6.4 96-44.8 243.2-44.8 313.6 76.8-147.2 96-153.6 294.4 19.2 403.2zM802.133 64c12.8 70.4-64 224-204.8 230.4-12.8-38.4 32-217.6 204.8-230.4z"></path></svg>
-            macOS
+            <span class="tab-label">macOS</span>
           </label>
-          <div role="tabpanel" id="panel-macos" class="tab-content pt-10 col-span-3">
+          <div role="tabpanel" id="panel-macos" class="tab-content pt-6 sm:pt-10 col-span-3">
             <div class="text-center mb-6">
               <svg aria-hidden="true" class="mx-auto w-12 h-12 text-base-content mb-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1195 1195"><path fill="currentColor" d="M1006.933 812.8c-32 153.6-115.2 211.2-147.2 249.6-32 25.6-121.6 25.6-153.6 6.4-38.4-25.6-134.4-25.6-166.4 0-44.8 32-115.2 19.2-128 12.8-256-179.2-352-716.8 12.8-774.4 64-12.8 134.4 32 134.4 32 51.2 25.6 70.4 12.8 115.2-6.4 96-44.8 243.2-44.8 313.6 76.8-147.2 96-153.6 294.4 19.2 403.2zM802.133 64c12.8 70.4-64 224-204.8 230.4-12.8-38.4 32-217.6 204.8-230.4z"></path></svg>
               <h3 class="text-xl font-bold">Mac downloads</h3>
@@ -461,9 +471,9 @@
           <label class="downloads-tab tab flex items-center justify-center gap-2 font-medium hover:bg-base-200 transition-colors" aria-label="Linux Downloads">
             <input type="radio" name="os_tabs" aria-controls="panel-linux" />
             <img src="assets/tux.svg" class="w-5 h-5 object-contain" alt="" aria-hidden="true" />
-            Linux
+            <span class="tab-label">Linux</span>
           </label>
-          <div role="tabpanel" id="panel-linux" class="tab-content pt-10 col-span-3">
+          <div role="tabpanel" id="panel-linux" class="tab-content pt-6 sm:pt-10 col-span-3">
              <div class="text-center mb-6">
               <img src="assets/tux.svg" class="mx-auto w-12 h-12 mb-2 object-contain" alt="" aria-hidden="true" />
               <h3 class="text-xl font-bold">Linux downloads</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -148,6 +148,15 @@
         min-height: 3.5rem;
         min-width: 0;
       }
+
+      /* Theme toggle: daisyUI `.swap` is inline-grid but `.btn` is inline-flex; on
+         the same element `.btn` wins and breaks the swap's grid centering, so
+         the icon sits off-center in the circle. Restore inline-grid here (higher
+         specificity than `.btn`) so the swap's place-content:center re-centers
+         the sun/moon icon. */
+      header .swap.swap-rotate {
+        display: inline-grid;
+      }
       .downloads-tab .tab-label {
         overflow: hidden;
         text-overflow: ellipsis;
@@ -333,8 +342,8 @@
         </a>
         <label class="swap swap-rotate btn btn-ghost btn-circle btn-sm h-10 w-10" aria-label="Toggle theme">
           <input type="checkbox" id="theme-toggle" class="theme-controller" value="business" aria-label="Toggle theme" />
-          <svg aria-hidden="true" class="swap-off fill-current w-5 h-5 absolute" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"/></svg>
-          <svg aria-hidden="true" class="swap-on fill-current w-5 h-5 absolute" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z"/></svg>
+          <svg aria-hidden="true" class="swap-off fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"/></svg>
+          <svg aria-hidden="true" class="swap-on fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z"/></svg>
         </label>
         <a href="#downloads" aria-label="Go to downloads section" class="btn btn-neutral btn-sm h-10 px-4 hidden sm:flex items-center gap-2 m-0">
           <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>

--- a/scripts/docs-ui-proof.ts
+++ b/scripts/docs-ui-proof.ts
@@ -11,7 +11,7 @@
  */
 import { existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
-import { chromium } from "playwright";
+import { chromium, type BrowserContext, type Page } from "playwright";
 import { writeError, writeOutput } from "./utils/cli-output";
 import { artifactDir, resolveProofEnv, resolveProofOutDir } from "./utils/proof-script-env";
 
@@ -59,7 +59,7 @@ const mapSequential = async <Item, Result>(
   return [head, ...rest];
 };
 
-const startLocalServer = (port: number): { url: string; stop: () => void } => {
+const startLocalServer = (port: number): { url: string; stop: () => Promise<void> } => {
   const server = Bun.serve({
     port,
     fetch(req) {
@@ -74,18 +74,16 @@ const startLocalServer = (port: number): { url: string; stop: () => void } => {
   return { url: `http://127.0.0.1:${String(port)}/`, stop: () => server.stop() };
 };
 
-const waitForCards = async (page: {
-  locator: (selector: string) => { waitFor: (opts: { timeout: number }) => Promise<unknown> };
-}): Promise<void> => {
+const waitForCards = async (page: Page): Promise<void> => {
   await page
     .locator(CARD_SELECTOR)
     .first()
     .waitFor({ timeout: NUM_10_000 })
-    .catch(() => undefined);
+    .then(() => undefined, () => undefined);
 };
 
 const proofViewport = async (
-  context: { newPage: () => Promise<import("playwright").Page> },
+  context: BrowserContext,
   viewport: Viewport,
   baseUrl: string,
 ): Promise<ViewportProof> => {
@@ -97,12 +95,12 @@ const proofViewport = async (
   await page
     .locator("#downloads")
     .scrollIntoViewIfNeeded()
-    .catch(() => undefined);
+    .then(() => undefined, () => undefined);
   await page
     .locator(CARD_SELECTOR)
     .last()
     .waitFor({ timeout: NUM_10_000 })
-    .catch(() => undefined);
+    .then(() => undefined, () => undefined);
   await page.screenshot({ path: resolve(OUT_DIR, `${viewport.name}-downloads.png`) });
 
   const metrics = await page.evaluate(() => {
@@ -136,14 +134,14 @@ const main = async (): Promise<void> => {
     await writeError(`No dist/docs-site at ${DIST_ROOT}. Run "bun run docs-site:bundle" first.`);
     process.exit(1);
   }
-  const host = TARGET ? { url: TARGET, stop: () => undefined } : startLocalServer(NUM_4567);
+  const host = TARGET ? { url: TARGET, stop: () => Promise.resolve() } : startLocalServer(NUM_4567);
   const browser = await chromium.launch();
   const context = await browser.newContext();
   const results = await mapSequential(VIEWPORTS, (viewport) =>
     proofViewport(context, viewport, host.url),
   );
   await browser.close();
-  host.stop();
+  await host.stop();
 
   const lines = results.map(
     (result) =>

--- a/scripts/docs-ui-proof.ts
+++ b/scripts/docs-ui-proof.ts
@@ -1,0 +1,83 @@
+/**
+ * Visual proof for the static docs site (bao.builders) at mobile / tablet / desktop
+ * viewports. Confirms no horizontal overflow and that all OS download tabs are
+ * visible without scrolling — the two regressions most likely to slip past curl.
+ *
+ * Usage:
+ *   bun run scripts/docs-ui-proof.ts                 # serve dist/docs-site locally, then proof
+ *   TARGET=https://bao.builders/ bun run scripts/docs-ui-proof.ts   # proof a live URL
+ *
+ * Output: artifacts/docs-ui-proof/<viewport>-downloads.png + a pass/fail summary.
+ */
+import { chromium } from "playwright";
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = new URL("../", import.meta.url).pathname;
+const DIST_ROOT = resolve(REPO_ROOT, "dist/docs-site");
+const OUT = resolve(REPO_ROOT, "artifacts/docs-ui-proof");
+mkdirSync(OUT, { recursive: true });
+
+const target = process.env.TARGET;
+let baseUrl: string;
+let server: { stop: () => void } | null = null;
+
+if (target) {
+  baseUrl = target;
+} else {
+  if (!existsSync(DIST_ROOT)) {
+    console.error(`No dist/docs-site at ${DIST_ROOT}. Run "bun run docs-site:bundle" first.`);
+    process.exit(1);
+  }
+  const port = 4567;
+  server = Bun.serve({
+    port,
+    fetch(req) {
+      const url = new URL(req.url);
+      let path = decodeURIComponent(url.pathname);
+      if (path === "/" || path === "") path = "/index.html";
+      const file = `${DIST_ROOT}${path}`;
+      if (!existsSync(file)) return new Response("not found", { status: 404 });
+      return new Response(Bun.file(file));
+    },
+  });
+  baseUrl = `http://127.0.0.1:${port}/`;
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const viewports = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const results: string[] = [];
+for (const vp of viewports) {
+  const page = await ctx.newPage();
+  await page.setViewportSize({ width: vp.width, height: vp.height });
+  await page.goto(baseUrl, { waitUntil: "networkidle" });
+  await page
+    .waitForSelector('[data-platform="windows"] .card', { timeout: 10000 })
+    .catch(() => {});
+  await page.locator("#downloads").scrollIntoViewIfNeeded().catch(() => {});
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: `${OUT}/${vp.name}-downloads.png` });
+  const ov = await page.evaluate(() => ({
+    sw: document.documentElement.scrollWidth,
+    iw: window.innerWidth,
+  }));
+  const tabsVisible = await page.$$eval(".downloads-tab .tab-label", (els) =>
+    els.every((e) => {
+      const r = (e as HTMLElement).getBoundingClientRect();
+      return r.left >= 0 && r.right <= window.innerWidth && r.width > 0;
+    }),
+  );
+  const overflow = ov.sw > ov.iw + 1;
+  results.push(`${vp.name}: overflow=${overflow} (sw=${ov.sw} iw=${ov.iw}) tabsAllVisible=${tabsVisible} ${overflow || !tabsVisible ? "FAIL" : "PASS"}`);
+  await page.close();
+}
+await browser.close();
+server?.stop();
+console.log(results.join("\n"));
+console.log("screenshots ->", OUT);
+if (results.some((r) => r.endsWith("FAIL"))) process.exit(1);

--- a/scripts/docs-ui-proof.ts
+++ b/scripts/docs-ui-proof.ts
@@ -4,33 +4,63 @@
  * visible without scrolling — the two regressions most likely to slip past curl.
  *
  * Usage:
- *   bun run scripts/docs-ui-proof.ts                 # serve dist/docs-site locally, then proof
- *   TARGET=https://bao.builders/ bun run scripts/docs-ui-proof.ts   # proof a live URL
+ *   bun run scripts/docs-ui-proof.ts                              # serve dist/docs-site locally, then proof
+ *   TARGET=https://bao.builders/ bun run scripts/docs-ui-proof.ts  # proof a live URL
  *
- * Output: artifacts/docs-ui-proof/<viewport>-downloads.png + a pass/fail summary.
+ * Output: <out>/<viewport>-downloads.png + a PASS/FAIL summary.
  */
-import { chromium } from "playwright";
 import { existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
+import { chromium } from "playwright";
+import { writeError, writeOutput } from "./utils/cli-output";
+import { artifactDir, resolveProofEnv, resolveProofOutDir } from "./utils/proof-script-env";
+
+const NUM_1 = 1;
+const NUM_4567 = 4567;
+const NUM_10_000 = 10_000;
+const NUM_800 = 800;
+const NUM_844 = 844;
+const NUM_1024 = 1024;
+const NUM_1280 = 1280;
+const NUM_390 = 390;
+const NUM_768 = 768;
 
 const REPO_ROOT = new URL("../", import.meta.url).pathname;
 const DIST_ROOT = resolve(REPO_ROOT, "dist/docs-site");
-const OUT = resolve(REPO_ROOT, "artifacts/docs-ui-proof");
-mkdirSync(OUT, { recursive: true });
+const OUT_DIR = resolveProofOutDir("DOCS_UI_PROOF_OUT", artifactDir("docs-ui-proof"));
+const TARGET = resolveProofEnv("TARGET");
+const CARD_SELECTOR = '[data-platform="windows"] .card';
 
-const target = process.env.TARGET;
-let baseUrl: string;
-let server: { stop: () => void } | null = null;
+type Viewport = { readonly name: string; readonly width: number; readonly height: number };
 
-if (target) {
-  baseUrl = target;
-} else {
-  if (!existsSync(DIST_ROOT)) {
-    console.error(`No dist/docs-site at ${DIST_ROOT}. Run "bun run docs-site:bundle" first.`);
-    process.exit(1);
-  }
-  const port = 4567;
-  server = Bun.serve({
+const VIEWPORTS: readonly Viewport[] = [
+  { name: "mobile", width: NUM_390, height: NUM_844 },
+  { name: "tablet", width: NUM_768, height: NUM_1024 },
+  { name: "desktop", width: NUM_1280, height: NUM_800 },
+] as const;
+
+type ViewportProof = {
+  readonly viewport: string;
+  readonly overflow: boolean;
+  readonly documentScrollWidth: number;
+  readonly innerWidth: number;
+  readonly tabsAllVisible: boolean;
+  readonly ok: boolean;
+};
+
+const mapSequential = async <Item, Result>(
+  items: readonly Item[],
+  mapper: (item: Item, index: number) => Promise<Result>,
+  index = 0,
+): Promise<Result[]> => {
+  if (index >= items.length) return [];
+  const head = await mapper(items[index], index);
+  const rest = await mapSequential(items, mapper, index + NUM_1);
+  return [head, ...rest];
+};
+
+const startLocalServer = (port: number): { url: string; stop: () => void } => {
+  const server = Bun.serve({
     port,
     fetch(req) {
       const url = new URL(req.url);
@@ -41,43 +71,97 @@ if (target) {
       return new Response(Bun.file(file));
     },
   });
-  baseUrl = `http://127.0.0.1:${port}/`;
-}
+  return { url: `http://127.0.0.1:${String(port)}/`, stop: () => server.stop() };
+};
 
-const browser = await chromium.launch();
-const ctx = await browser.newContext();
-const viewports = [
-  { name: "mobile", width: 390, height: 844 },
-  { name: "tablet", width: 768, height: 1024 },
-  { name: "desktop", width: 1280, height: 800 },
-];
-const results: string[] = [];
-for (const vp of viewports) {
-  const page = await ctx.newPage();
-  await page.setViewportSize({ width: vp.width, height: vp.height });
-  await page.goto(baseUrl, { waitUntil: "networkidle" });
+const waitForCards = async (page: {
+  locator: (selector: string) => { waitFor: (opts: { timeout: number }) => Promise<unknown> };
+}): Promise<void> => {
   await page
-    .waitForSelector('[data-platform="windows"] .card', { timeout: 10000 })
-    .catch(() => {});
-  await page.locator("#downloads").scrollIntoViewIfNeeded().catch(() => {});
-  await page.waitForTimeout(500);
-  await page.screenshot({ path: `${OUT}/${vp.name}-downloads.png` });
-  const ov = await page.evaluate(() => ({
-    sw: document.documentElement.scrollWidth,
-    iw: window.innerWidth,
-  }));
-  const tabsVisible = await page.$$eval(".downloads-tab .tab-label", (els) =>
-    els.every((e) => {
-      const r = (e as HTMLElement).getBoundingClientRect();
-      return r.left >= 0 && r.right <= window.innerWidth && r.width > 0;
-    }),
-  );
-  const overflow = ov.sw > ov.iw + 1;
-  results.push(`${vp.name}: overflow=${overflow} (sw=${ov.sw} iw=${ov.iw}) tabsAllVisible=${tabsVisible} ${overflow || !tabsVisible ? "FAIL" : "PASS"}`);
+    .locator(CARD_SELECTOR)
+    .first()
+    .waitFor({ timeout: NUM_10_000 })
+    .catch(() => undefined);
+};
+
+const proofViewport = async (
+  context: { newPage: () => Promise<import("playwright").Page> },
+  viewport: Viewport,
+  baseUrl: string,
+): Promise<ViewportProof> => {
+  const page = await context.newPage();
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.goto(baseUrl, { waitUntil: "domcontentloaded", timeout: NUM_10_000 });
+  await page.locator("body").waitFor({ state: "visible", timeout: NUM_10_000 });
+  await waitForCards(page);
+  await page
+    .locator("#downloads")
+    .scrollIntoViewIfNeeded()
+    .catch(() => undefined);
+  await page
+    .locator(CARD_SELECTOR)
+    .last()
+    .waitFor({ timeout: NUM_10_000 })
+    .catch(() => undefined);
+  await page.screenshot({ path: resolve(OUT_DIR, `${viewport.name}-downloads.png`) });
+
+  const metrics = await page.evaluate(() => {
+    const labels = Array.from(document.querySelectorAll(".downloads-tab .tab-label"));
+    const tabsAllVisible = labels.every((label) => {
+      const rect = label.getBoundingClientRect();
+      return rect.left >= 0 && rect.right <= window.innerWidth && rect.width > 0;
+    });
+    return {
+      documentScrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+      tabsAllVisible,
+    };
+  });
+
   await page.close();
-}
-await browser.close();
-server?.stop();
-console.log(results.join("\n"));
-console.log("screenshots ->", OUT);
-if (results.some((r) => r.endsWith("FAIL"))) process.exit(1);
+  const overflow = metrics.documentScrollWidth > metrics.innerWidth + NUM_1;
+  return {
+    viewport: viewport.name,
+    overflow,
+    documentScrollWidth: metrics.documentScrollWidth,
+    innerWidth: metrics.innerWidth,
+    tabsAllVisible: metrics.tabsAllVisible,
+    ok: !overflow && metrics.tabsAllVisible,
+  };
+};
+
+const main = async (): Promise<void> => {
+  mkdirSync(OUT_DIR, { recursive: true });
+  if (!TARGET && !existsSync(DIST_ROOT)) {
+    await writeError(`No dist/docs-site at ${DIST_ROOT}. Run "bun run docs-site:bundle" first.`);
+    process.exit(1);
+  }
+  const host = TARGET ? { url: TARGET, stop: () => undefined } : startLocalServer(NUM_4567);
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const results = await mapSequential(VIEWPORTS, (viewport) =>
+    proofViewport(context, viewport, host.url),
+  );
+  await browser.close();
+  host.stop();
+
+  const lines = results.map(
+    (result) =>
+      `${result.viewport}: overflow=${String(result.overflow)} (sw=${String(result.documentScrollWidth)} iw=${String(result.innerWidth)}) tabsAllVisible=${String(result.tabsAllVisible)} ${result.ok ? "PASS" : "FAIL"}`,
+  );
+  await writeOutput(`${lines.join("\n")}\nscreenshots -> ${OUT_DIR}`);
+  const failures = results.filter((result) => !result.ok);
+  if (failures.length > 0) {
+    await writeError(
+      failures
+        .map(
+          (failure) =>
+            `${failure.viewport}: overflow=${String(failure.overflow)} tabsAllVisible=${String(failure.tabsAllVisible)}`,
+        )
+        .join("\n"),
+    );
+    process.exitCode = 1;
+  }
+};
+
+await main();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Targeted UI/UX and mobile/tablet responsiveness improvements to the bao.builders download page (`docs/index.html`), plus a reusable Playwright proof script. No framework or SSOT change — still daisyUI `corporate`/`business` + Tailwind v4 via the shared `packages/client/assets/css/main.css`.

## Problems fixed

1. **Theme-toggle icon sat off-center in the navbar circle.** daisyUI `.swap` is `inline-grid` (centers children via `place-content:center` + `grid-column-start:1`) but `.btn` is `inline-flex`; on the same element `.btn` won, so the swap's grid centering broke. The swap-on/off SVGs also carried a Tailwind `absolute` class, pulling them out of grid flow — grid tracks collapsed to 0px and the 20px icon overflowed from the cell center (+10px,+10px offset). Fix: drop `absolute` from both SVGs (so they size the grid track again) and add `header .swap.swap-rotate { display:inline-grid }` (higher specificity than `.btn`) to restore grid centering. Verified: icon center == button center (offset 0,0) at mobile + desktop; toggle still flips corporate↔business with correct sun/moon opacity.
2. **OS tab selector horizontally scrolled on phones.** `repeat(3, minmax(10rem,1fr))` forced a 30rem row that overflowed; the `@media (max-width:767px)` override set `width: max-content`, so Windows/macOS/Linux tabs were hidden behind a swipe. → `minmax(0,1fr)` + `min-w-0` so all three always fit one row; removed the `max-content` override. Tab labels wrapped in `.tab-label` (ellipsis safeguard).
3. **Tablets got a hamburger despite having room.** Inline nav was `hidden lg:flex`; hamburger `lg:hidden`. → Nav now `hidden md:flex`, hamburger `md:hidden` — tablets get real nav links.
4. **Dead space under tabs on phones.** Tabpanel `pt-10` → `pt-6 sm:pt-10`.
5. **Hero h1 jumped 4xl → 6xl.** Added `sm:text-5xl` step for a smoother ramp.
6. **Touch targets under 44px.** Nav links `h-10` → `h-11` (WCAG 2.5.5).
7. **SHA row overflowed narrow cards.** `.release-sha` now `flex-wrap`; hash code `max-width:100%` (was fixed `12rem`).
8. **Section headings hid under navbar on sm+.** `scroll-padding-top` 5rem → 5.5rem.
9. **No dark theme-color for browser chrome.** Added `prefers-color-scheme: dark` `theme-color` meta; `viewport-fit=cover` for notched devices.

## Visual proof (Playwright, 3 viewports)

`bun run scripts/docs-ui-proof.ts` (local bundle) and `TARGET=https://bao.builders/ bun run scripts/docs-ui-proof.ts` (live) — both **PASS** at mobile (390px), tablet (768px), desktop (1280px): no horizontal overflow, all OS tabs visible. Theme-toggle centering measured at offset 0,0 on both local and live.

## Lint

`scripts/docs-ui-proof.ts` is lint-clean under the repo's strict gates: `validate:no-try-catch` (uses `.then(() => undefined, () => undefined)` per `scripts/utils/playwright-settle.ts`, not `.catch`), real Playwright types (`import { chromium, type BrowserContext, type Page }`), and `Promise<void>`-typed server stop (no `void` operator, no floating promises). `bun run lint` passes (biome + eslint + typecheck).

## Deployed

Rebuilt `docs-site:bundle` (16 files, 764 MiB — release binaries unchanged) and published to `pixie-ss1-ftp.porkbun.com/` (bao.builders). Live site verified: `index.html` HTTP 200, manifest still 9 files / 3 platforms, theme-toggle icon centered (offset 0,0), toggle flips theme correctly.

## Notes

- Only `docs/index.html` (tracked) + `scripts/docs-ui-proof.ts` (new, lint-clean) are committed. `docs/assets/docs.generated.css` and `docs/releases/manifest.json` stay gitignored (regenerated by `bun run build:docs-site`).
- FTP credentials used from the environment only; not committed. Rotate the password at the host before storing it as a repository secret.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33a6822f-9887-44b6-ae6a-c1882dec42cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33a6822f-9887-44b6-ae6a-c1882dec42cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

